### PR TITLE
Replace logo block with brand text

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,10 +24,7 @@ export default function App(){
     <div className="min-h-screen bg-neutral-50 text-neutral-900">
       <header className="sticky top-0 z-10 bg-white/90 backdrop-blur border-b border-neutral-200">
         <div className="mx-auto max-w-6xl px-4 py-3 flex items-center gap-3">
-          <div className="flex items-center gap-2 font-semibold">
-            <div className="h-7 w-7 rounded-lg bg-neutral-900 text-white grid place-items-center">OY</div>
-            <span>OpenYum</span>
-          </div>
+          <span className="text-xl sm:text-2xl font-bold">OpenYum</span>
           <nav className="ml-auto flex items-center gap-1">
             <NavItem to="/browse">Browse</NavItem>
             <NavItem to="/submit">Submit Recipe</NavItem>


### PR DESCRIPTION
## Summary
- Replace header logo block with a single span displaying "OpenYum".
- Style brand text with responsive Tailwind classes `text-xl sm:text-2xl font-bold`.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898294d7e648324acfe6d8d1fac69f4