### PR TITLE
Remove header logo and extra nav links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,17 +24,10 @@ export default function App(){
     <div className="min-h-screen bg-neutral-50 text-neutral-900">
       <header className="sticky top-0 z-10 bg-white/90 backdrop-blur border-b border-neutral-200">
         <div className="mx-auto max-w-6xl px-4 py-3 flex items-center gap-3">
-          <div className="flex items-center gap-2 font-semibold">
-            <div className="h-7 w-7 rounded-lg bg-neutral-900 text-white grid place-items-center">OY</div>
-            <span>OpenYum</span>
-          </div>
           <nav className="ml-auto flex items-center gap-1">
             <NavItem to="/browse">Browse</NavItem>
             <NavItem to="/submit">Submit Recipe</NavItem>
             <NavItem to="/support">Support</NavItem>
-            <NavItem to="/contact">Contact</NavItem>
-            <NavItem to="/terms">Terms</NavItem>
-            <NavItem to="/privacy">Privacy</NavItem>
           </nav>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- remove "OY" logo block from header
- trim navigation links to only Browse, Submit Recipe, Support

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898294af7408324941d5eb6bf9c46ac