### PR TITLE
Add login and signup pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,8 @@ import Terms from './pages/Terms.jsx'
 import Privacy from './pages/Privacy.jsx'
 import Support from './pages/Support.jsx'
 import Recipe from './pages/Recipe.jsx'
+import Login from './pages/Login.jsx'
+import Signup from './pages/Signup.jsx'
 
 function NavItem({ to, children }){
   return (
@@ -35,6 +37,8 @@ export default function App(){
             <NavItem to="/contact">Contact</NavItem>
             <NavItem to="/terms">Terms</NavItem>
             <NavItem to="/privacy">Privacy</NavItem>
+            <NavItem to="/login">Login</NavItem>
+            <NavItem to="/signup">Sign Up</NavItem>
           </nav>
         </div>
       </header>
@@ -50,6 +54,8 @@ export default function App(){
           <Route path="/terms" element={<Terms />} />
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/support" element={<Support />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
         </Routes>
       </main>
 

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import AuthBox from '../components/AuthBox.jsx'
+
+export default function Login(){
+  return (
+    <div className="grid gap-3">
+      <h2 className="font-semibold">Login</h2>
+      <AuthBox />
+    </div>
+  )
+}

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import AuthBox from '../components/AuthBox.jsx'
+
+export default function Signup(){
+  return (
+    <div className="grid gap-3">
+      <h2 className="font-semibold">Sign Up</h2>
+      <AuthBox />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Add dedicated Login and Sign Up pages rendering existing AuthBox
- Wire navigation items for login and sign up in main header
- Register routes for login and sign up pages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68982950674483248796dd5de39687d4