### PR TITLE
feat: add recipe pagination

### DIFF
--- a/src/pages/Browse.jsx
+++ b/src/pages/Browse.jsx
@@ -8,6 +8,8 @@ export default function Browse(){
   const [diet, setDiet] = useState('')
   const [meal, setMeal] = useState('')
   const [maxTime, setMaxTime] = useState(180)
+  const [page, setPage] = useState(1)
+  const perPage = 24
 
   useEffect(() => {
     (async () => {
@@ -30,11 +32,14 @@ export default function Browse(){
     return matchesQ && matchesDiet && matchesMeal && matchesTime
   })
 
+  const totalPages = Math.max(1, Math.ceil(filtered.length / perPage))
+  const paginated = filtered.slice((page - 1) * perPage, page * perPage)
+
   return (
     <div className="grid gap-4">
       <div className="rounded-2xl border border-neutral-200 bg-white p-4 grid gap-3 md:grid-cols-4">
-        <input value={q} onChange={e=>setQ(e.target.value)} placeholder="Search title, ingredients, tags…" className="rounded-xl border border-neutral-300 px-3 py-2 outline-none focus:ring-2 focus:ring-neutral-300 md:col-span-2" />
-        <select value={diet} onChange={e=>setDiet(e.target.value)} className="rounded-xl border border-neutral-300 px-3 py-2">
+        <input value={q} onChange={e=>{setQ(e.target.value); setPage(1)}} placeholder="Search title, ingredients, tags…" className="rounded-xl border border-neutral-300 px-3 py-2 outline-none focus:ring-2 focus:ring-neutral-300 md:col-span-2" />
+        <select value={diet} onChange={e=>{setDiet(e.target.value); setPage(1)}} className="rounded-xl border border-neutral-300 px-3 py-2">
           <option value="">Any diet</option>
           <option>Vegetarian</option>
           <option>Vegan</option>
@@ -43,7 +48,7 @@ export default function Browse(){
           <option>Keto</option>
           <option>None</option>
         </select>
-        <select value={meal} onChange={e=>setMeal(e.target.value)} className="rounded-xl border border-neutral-300 px-3 py-2">
+        <select value={meal} onChange={e=>{setMeal(e.target.value); setPage(1)}} className="rounded-xl border border-neutral-300 px-3 py-2">
           <option value="">Any meal</option>
           <option>Breakfast</option>
           <option>Lunch</option>
@@ -53,13 +58,13 @@ export default function Browse(){
         </select>
         <div className="flex items-center gap-3 md:col-span-2">
           <label className="text-sm text-neutral-600">Max time</label>
-          <input type="range" min={0} max={240} step={5} value={maxTime} onChange={e=>setMaxTime(Number(e.target.value))} className="w-full" />
+          <input type="range" min={0} max={240} step={5} value={maxTime} onChange={e=>{setMaxTime(Number(e.target.value)); setPage(1)}} className="w-full" />
           <div className="text-sm w-16 text-right">{maxTime}m</div>
         </div>
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {filtered.map(r => (
+        {paginated.map(r => (
           <article key={r.id} className="rounded-2xl border border-neutral-200 bg-white p-4 hover:shadow-sm transition">
             <div className="flex items-start justify-between gap-2">
               <h3 className="font-semibold leading-tight line-clamp-2">{r.title}</h3>
@@ -73,6 +78,14 @@ export default function Browse(){
           </article>
         ))}
       </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center gap-4 mt-4">
+          <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1} className="px-3 py-1 text-sm rounded-lg border border-neutral-300 disabled:opacity-50">Previous</button>
+          <span className="text-sm">Page {page} of {totalPages}</span>
+          <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="px-3 py-1 text-sm rounded-lg border border-neutral-300 disabled:opacity-50">Next</button>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add client-side pagination to Browse page to limit recipes per page
- include controls for navigating pages and reset when filters change

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68982dcb27fc83248c1c22d6b0a75f11