### PR TITLE
Replace homepage login bar with link to dedicated page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Terms from './pages/Terms.jsx'
 import Privacy from './pages/Privacy.jsx'
 import Support from './pages/Support.jsx'
 import Recipe from './pages/Recipe.jsx'
+import Login from './pages/Login.jsx'
 
 function NavItem({ to, children }){
   return (
@@ -35,6 +36,7 @@ export default function App(){
             <NavItem to="/contact">Contact</NavItem>
             <NavItem to="/terms">Terms</NavItem>
             <NavItem to="/privacy">Privacy</NavItem>
+            <NavLink to="/login" className="px-3 py-2 text-sm text-neutral-600 underline-offset-2 hover:underline">Login</NavLink>
           </nav>
         </div>
       </header>
@@ -50,6 +52,7 @@ export default function App(){
           <Route path="/terms" element={<Terms />} />
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/support" element={<Support />} />
+          <Route path="/login" element={<Login />} />
         </Routes>
       </main>
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import AuthBox from '../components/AuthBox.jsx'
 
 export default function Home(){
   return (
@@ -30,10 +29,7 @@ export default function Home(){
         </div>
       </section>
 
-      <section className="grid gap-3">
-        <h2 className="font-semibold">Login</h2>
-        <AuthBox />
-      </section>
+      {/* Login moved to dedicated page */}
     </div>
   )
 }

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import AuthBox from '../components/AuthBox.jsx'
+
+export default function Login(){
+  return (
+    <div className="max-w-sm grid gap-4">
+      <h1 className="text-2xl font-bold">Login</h1>
+      <AuthBox />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Move login form from homepage to new `/login` page
- Add header login link and route to new page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689831b6e400832488bd6a08f2976566