### PR TITLE
Add authentication pages and login prompt

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,8 @@ import Terms from './pages/Terms.jsx'
 import Privacy from './pages/Privacy.jsx'
 import Support from './pages/Support.jsx'
 import Recipe from './pages/Recipe.jsx'
+import Login from './pages/Login.jsx'
+import Register from './pages/Register.jsx'
 
 function NavItem({ to, children }){
   return (
@@ -50,6 +52,8 @@ export default function App(){
           <Route path="/terms" element={<Terms />} />
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/support" element={<Support />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
         </Routes>
       </main>
 

--- a/src/components/AuthInfoPanel.jsx
+++ b/src/components/AuthInfoPanel.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export default function AuthInfoPanel(){
+  return (
+    <div className="rounded-2xl border border-neutral-200 bg-white p-6">
+      <h2 className="text-xl font-semibold">OpenYum</h2>
+      <p className="mt-2 text-sm text-neutral-700">Ad-free community recipes.</p>
+      <ul className="mt-4 list-disc pl-5 text-sm text-neutral-700 space-y-1">
+        <li>Discover new dishes</li>
+        <li>Share your own recipes</li>
+        <li>Manage your submissions</li>
+      </ul>
+    </div>
+  )
+}

--- a/src/components/AuthTabs.jsx
+++ b/src/components/AuthTabs.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { NavLink } from 'react-router-dom'
+
+export default function AuthTabs(){
+  return (
+    <div className="flex border-b border-neutral-200 mb-4">
+      <NavLink
+        to="/login"
+        className={({isActive}) =>
+          'px-3 py-2 text-sm ' +
+          (isActive ? 'border-b-2 border-neutral-900 font-medium' : 'text-neutral-600 hover:text-neutral-900')
+        }
+      >Login</NavLink>
+      <NavLink
+        to="/register"
+        className={({isActive}) =>
+          'ml-4 px-3 py-2 text-sm ' +
+          (isActive ? 'border-b-2 border-neutral-900 font-medium' : 'text-neutral-600 hover:text-neutral-900')
+        }
+      >Register</NavLink>
+    </div>
+  )
+}

--- a/src/components/LoginRequired.jsx
+++ b/src/components/LoginRequired.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+export default function LoginRequired(){
+  return (
+    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm grid place-items-center p-4">
+      <div className="max-w-sm w-full rounded-2xl border border-neutral-200 bg-white p-6">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-xl">→</span>
+          <h2 className="text-lg font-semibold">Login Required</h2>
+        </div>
+        <p className="text-sm text-neutral-700">Please log in to submit a recipe.</p>
+        <div className="mt-4 rounded-xl border border-blue-200 bg-blue-50 p-4 text-sm">
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Submit new recipes</li>
+            <li>Track your recipe submissions</li>
+            <li>Manage your submitted recipes</li>
+          </ul>
+        </div>
+        <div className="mt-6 grid gap-2">
+          <Link to="/login" className="px-4 py-2 rounded-xl bg-neutral-900 text-white text-sm text-center">Log In</Link>
+          <Link to="/register" className="px-4 py-2 rounded-xl border border-neutral-300 text-sm text-center hover:bg-neutral-100">Create an Account</Link>
+          <Link to="/" className="text-sm text-center underline">Return to Homepage</Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+import AuthTabs from '../components/AuthTabs.jsx'
+import AuthInfoPanel from '../components/AuthInfoPanel.jsx'
+
+export default function Login(){
+  const [identifier, setIdentifier] = useState('')
+  const [password, setPassword] = useState('')
+
+  function handleSubmit(e){
+    e.preventDefault()
+    // login logic placeholder
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto grid gap-6 md:grid-cols-2">
+      <div className="rounded-2xl border border-neutral-200 bg-white p-6">
+        <AuthTabs />
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <div>
+            <label className="block text-sm font-medium">Username or Email</label>
+            <input type="text" value={identifier} onChange={e=>setIdentifier(e.target.value)} className="mt-1 w-full rounded-xl border border-neutral-300 px-3 py-2" required />
+          </div>
+          <div>
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">Password</label>
+              <a href="#" className="text-sm underline">Forgot password?</a>
+            </div>
+            <input type="password" value={password} onChange={e=>setPassword(e.target.value)} className="mt-1 w-full rounded-xl border border-neutral-300 px-3 py-2" required />
+          </div>
+          <button className="mt-2 px-4 py-2 rounded-xl bg-neutral-900 text-white text-sm">Login</button>
+        </form>
+        <div className="mt-4 text-sm text-center">
+          Don’t have an account? <Link to="/register" className="underline">Register</Link>
+        </div>
+      </div>
+      <AuthInfoPanel />
+    </div>
+  )
+}

--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+import AuthTabs from '../components/AuthTabs.jsx'
+import AuthInfoPanel from '../components/AuthInfoPanel.jsx'
+
+export default function Register(){
+  const [username, setUsername] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [newsletter, setNewsletter] = useState(false)
+
+  const isValid = username && email && password
+
+  function handleSubmit(e){
+    e.preventDefault()
+    // registration logic placeholder
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto grid gap-6 md:grid-cols-2">
+      <div className="rounded-2xl border border-neutral-200 bg-white p-6">
+        <AuthTabs />
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <div>
+            <label className="block text-sm font-medium">Username</label>
+            <input type="text" value={username} onChange={e=>setUsername(e.target.value)} className="mt-1 w-full rounded-xl border border-neutral-300 px-3 py-2" required />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Email</label>
+            <input type="email" value={email} onChange={e=>setEmail(e.target.value)} className="mt-1 w-full rounded-xl border border-neutral-300 px-3 py-2" required />
+          </div>
+          <div>
+            <label className="block text-sm font-medium">Password</label>
+            <input type="password" value={password} onChange={e=>setPassword(e.target.value)} className="mt-1 w-full rounded-xl border border-neutral-300 px-3 py-2" required />
+          </div>
+          <div className="flex items-start gap-2">
+            <input id="newsletter" type="checkbox" checked={newsletter} onChange={e=>setNewsletter(e.target.checked)} className="mt-1" />
+            <div>
+              <label htmlFor="newsletter" className="text-sm">Sign up for our newsletter</label>
+              <p className="text-xs text-neutral-500">Occasional updates. You can unsubscribe anytime.</p>
+            </div>
+          </div>
+          <button disabled={!isValid} className="mt-2 px-4 py-2 rounded-xl bg-neutral-900 text-white text-sm disabled:opacity-50 disabled:cursor-not-allowed">Register</button>
+        </form>
+        <div className="mt-4 text-sm text-center">
+          Already have an account? <Link to="/login" className="underline">Login</Link>
+        </div>
+      </div>
+      <AuthInfoPanel />
+    </div>
+  )
+}

--- a/src/pages/Submit.jsx
+++ b/src/pages/Submit.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { supabase } from '../supabaseClient'
+import LoginRequired from '../components/LoginRequired.jsx'
 
 export default function Submit(){
   const [title, setTitle] = useState('')
@@ -12,6 +13,15 @@ export default function Submit(){
   const [cookTime, setCookTime] = useState(30)
   const [difficulty, setDifficulty] = useState('Easy')
   const [msg, setMsg] = useState('')
+  const [user, setUser] = useState(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUser(data.user)
+      setLoading(false)
+    })
+  }, [])
 
   async function handleSubmit(e){
     e.preventDefault()
@@ -43,6 +53,8 @@ export default function Submit(){
       setTitle(''); setDescription(''); setIngredients(''); setSteps(''); setCuisine('')
     }
   }
+
+  if (!loading && !user) return <LoginRequired />
 
   return (
     <div className="grid gap-4">


### PR DESCRIPTION
## Summary
- add Login and Register pages with shared info panel and tab navigation
- create login-required modal and gate recipe submission
- wire up routes for new auth pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68983250e130832490b3b2fddbd31bfd