### PR TITLE
feat: add recipe filter panel with URL sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.47.0",
@@ -20,6 +21,7 @@
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.7",
-    "vite": "^5.3.3"
+    "vite": "^5.3.3",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/components/filters/FilterChip.tsx
+++ b/src/components/filters/FilterChip.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export interface FilterChipProps {
+  label: string;
+  active: boolean;
+  onToggle: () => void;
+  ariaPressed?: boolean;
+}
+
+export const FilterChip: React.FC<FilterChipProps> = ({ label, active, onToggle, ariaPressed }) => {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={ariaPressed ?? active}
+      className={`rounded-full border px-3 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+        active
+          ? 'border-blue-600 bg-blue-600 text-white'
+          : 'border-gray-300 bg-white hover:bg-gray-50'
+      }`}
+    >
+      {label}
+    </button>
+  );
+};
+
+export default FilterChip;

--- a/src/components/filters/FilterGroup.tsx
+++ b/src/components/filters/FilterGroup.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import FilterChip from './FilterChip';
+
+export interface FilterGroupProps {
+  title: string;
+  options: string[];
+  value: string[] | string | null;
+  onChange: (value: string[] | string | null) => void;
+  multi?: boolean;
+}
+
+export const FilterGroup: React.FC<FilterGroupProps> = ({
+  title,
+  options,
+  value,
+  onChange,
+  multi = false,
+}) => {
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    const mql = window.matchMedia('(min-width: 768px)');
+    setOpen(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setOpen(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  const handleToggle = (option: string) => {
+    if (multi) {
+      const current = Array.isArray(value) ? value : [];
+      const next = current.includes(option)
+        ? current.filter((v) => v !== option)
+        : [...current, option];
+      onChange(next);
+    } else {
+      const current = typeof value === 'string' ? value : null;
+      const next = current === option ? null : option;
+      onChange(next);
+    }
+  };
+
+  const isActive = (option: string) => {
+    if (multi) {
+      return Array.isArray(value) && value.includes(option);
+    }
+    return value === option;
+  };
+
+  return (
+    <details open={open} className="space-y-2">
+      <summary className="font-medium cursor-pointer md:cursor-default list-none">
+        {title}
+      </summary>
+      <div className="flex flex-wrap gap-2">
+        {options.map((option) => (
+          <FilterChip
+            key={option}
+            label={option}
+            active={isActive(option)}
+            ariaPressed={isActive(option)}
+            onToggle={() => handleToggle(option)}
+          />
+        ))}
+      </div>
+    </details>
+  );
+};
+
+export default FilterGroup;

--- a/src/components/filters/FilterPanel.tsx
+++ b/src/components/filters/FilterPanel.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import FilterGroup from './FilterGroup';
+import { Filters } from '../../hooks/useRecipeFilters';
+
+interface FilterPanelProps {
+  filters: Filters;
+  setFilter: (key: keyof Filters, value: string[] | string | null) => void;
+  clearAll: () => void;
+  isActive: boolean;
+}
+
+const mealOptions = ['Breakfast', 'Lunch', 'Dinner', 'Snack', 'Dessert'];
+const dietOptions = ['Vegetarian', 'Vegan', 'Keto', 'Paleo', 'Low-carb', 'Healthy'];
+const allergyOptions = ['Gluten-free', 'Dairy-free', 'Nut-free', 'Egg-free', 'Soy-free'];
+const dishOptions = ['Appetizer', 'Main Course', 'Side Dish', 'Dessert', 'Salad', 'Soup', 'Snack', 'Beverage', 'Bread', 'Sauce'];
+const cuisineOptions = ['Italian', 'Mexican', 'Chinese', 'Indian', 'American', 'French', 'Mediterranean', 'Japanese', 'Thai', 'Greek'];
+const difficultyOptions = ['Easy', 'Moderate', 'Challenging'];
+const timeOptions = ['15 minutes or less', '30 minutes or less', '45 minutes or less', '60 minutes or less', 'Over 60 minutes'];
+const featureOptions = ['Image', 'Healthy', 'Meal Prep'];
+
+export const FilterPanel: React.FC<FilterPanelProps> = ({
+  filters,
+  setFilter,
+  clearAll,
+  isActive,
+}) => {
+  return (
+    <section className="rounded-2xl border border-neutral-200 bg-white p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Filter Recipes</h2>
+        {isActive && (
+          <button
+            type="button"
+            onClick={clearAll}
+            className="text-sm text-blue-600 hover:underline"
+          >
+            Clear all
+          </button>
+        )}
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        <FilterGroup
+          title="Meal Type"
+          options={mealOptions}
+          value={filters.meal}
+          onChange={(v) => setFilter('meal', v)}
+          multi
+        />
+        <FilterGroup
+          title="Diet"
+          options={dietOptions}
+          value={filters.diet}
+          onChange={(v) => setFilter('diet', v)}
+          multi
+        />
+        <FilterGroup
+          title="Allergies"
+          options={allergyOptions}
+          value={filters.allergy}
+          onChange={(v) => setFilter('allergy', v)}
+          multi
+        />
+        <FilterGroup
+          title="Dish Type"
+          options={dishOptions}
+          value={filters.dish}
+          onChange={(v) => setFilter('dish', v)}
+          multi
+        />
+        <FilterGroup
+          title="Cuisine"
+          options={cuisineOptions}
+          value={filters.cuisine}
+          onChange={(v) => setFilter('cuisine', v)}
+          multi
+        />
+        <FilterGroup
+          title="Difficulty"
+          options={difficultyOptions}
+          value={filters.difficulty}
+          onChange={(v) => setFilter('difficulty', v)}
+        />
+        <FilterGroup
+          title="Time"
+          options={timeOptions}
+          value={filters.time}
+          onChange={(v) => setFilter('time', v)}
+        />
+        <FilterGroup
+          title="Features"
+          options={featureOptions}
+          value={filters.feat}
+          onChange={(v) => setFilter('feat', v)}
+          multi
+        />
+      </div>
+    </section>
+  );
+};
+
+export default FilterPanel;

--- a/src/hooks/applyFilters.test.ts
+++ b/src/hooks/applyFilters.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { applyFilters, Filters, Recipe } from './useRecipeFilters';
+
+const recipes: Recipe[] = [
+  {
+    title: 'Pancakes',
+    mealType: ['Breakfast'],
+    diet: ['Vegetarian'],
+    allergies: ['Gluten-free'],
+    dishType: 'Dessert',
+    cuisine: 'American',
+    difficulty: 'Easy',
+    timeMinutes: 20,
+    features: ['Image'],
+  },
+  {
+    title: 'Tacos',
+    mealType: ['Lunch', 'Dinner'],
+    diet: ['Keto'],
+    dishType: 'Main Course',
+    cuisine: 'Mexican',
+    difficulty: 'Moderate',
+    timeMinutes: 40,
+    features: ['Healthy'],
+  },
+  {
+    title: 'Curry',
+    mealType: ['Dinner'],
+    diet: ['Vegan'],
+    dishType: 'Main Course',
+    cuisine: 'Indian',
+    difficulty: 'Challenging',
+    timeMinutes: 70,
+    features: ['Meal Prep'],
+  },
+];
+
+describe('applyFilters', () => {
+  it('returns all recipes when no filters', () => {
+    const filters: Filters = {
+      meal: [],
+      diet: [],
+      allergy: [],
+      dish: [],
+      cuisine: [],
+      difficulty: null,
+      time: null,
+      feat: [],
+    };
+    expect(applyFilters(recipes, filters)).toHaveLength(3);
+  });
+
+  it('filters by meal type multi-select', () => {
+    const filters: Filters = {
+      meal: ['Breakfast'],
+      diet: [],
+      allergy: [],
+      dish: [],
+      cuisine: [],
+      difficulty: null,
+      time: null,
+      feat: [],
+    };
+    const res = applyFilters(recipes, filters);
+    expect(res).toHaveLength(1);
+    expect(res[0].title).toBe('Pancakes');
+  });
+
+  it('filters by difficulty single-select', () => {
+    const filters: Filters = {
+      meal: [],
+      diet: [],
+      allergy: [],
+      dish: [],
+      cuisine: [],
+      difficulty: 'Moderate',
+      time: null,
+      feat: [],
+    };
+    const res = applyFilters(recipes, filters);
+    expect(res).toHaveLength(1);
+    expect(res[0].title).toBe('Tacos');
+  });
+
+  it('filters by time', () => {
+    const filters: Filters = {
+      meal: [],
+      diet: [],
+      allergy: [],
+      dish: [],
+      cuisine: [],
+      difficulty: null,
+      time: '30 minutes or less',
+      feat: [],
+    };
+    const res = applyFilters(recipes, filters);
+    expect(res).toHaveLength(1);
+    expect(res[0].title).toBe('Pancakes');
+  });
+});

--- a/src/hooks/useRecipeFilters.ts
+++ b/src/hooks/useRecipeFilters.ts
@@ -1,0 +1,168 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export type Recipe = {
+  title: string;
+  mealType?: string[];
+  diet?: string[];
+  allergies?: string[];
+  dishType?: string;
+  cuisine?: string;
+  difficulty?: 'Easy' | 'Moderate' | 'Challenging';
+  timeMinutes?: number;
+  features?: string[];
+};
+
+export type Filters = {
+  meal: string[];
+  diet: string[];
+  allergy: string[];
+  dish: string[];
+  cuisine: string[];
+  difficulty: string | null;
+  time: string | null;
+  feat: string[];
+};
+
+const defaultFilters: Filters = {
+  meal: [],
+  diet: [],
+  allergy: [],
+  dish: [],
+  cuisine: [],
+  difficulty: null,
+  time: null,
+  feat: [],
+};
+
+const STORAGE_KEY = 'recipeFilters';
+
+const parseCsv = (v: string | null): string[] => (v ? v.split(',').filter(Boolean) : []);
+
+export const useRecipeFilters = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [filters, setFilters] = useState<Filters>(defaultFilters);
+
+  // hydrate from URL or localStorage
+  useEffect(() => {
+    const params: Filters = {
+      meal: parseCsv(searchParams.get('meal')),
+      diet: parseCsv(searchParams.get('diet')),
+      allergy: parseCsv(searchParams.get('allergy')),
+      dish: parseCsv(searchParams.get('dish')),
+      cuisine: parseCsv(searchParams.get('cuisine')),
+      difficulty: searchParams.get('difficulty'),
+      time: searchParams.get('time'),
+      feat: parseCsv(searchParams.get('feat')),
+    };
+
+    const hasParams = Array.from(searchParams.keys()).length > 0;
+    if (hasParams) {
+      setFilters(params);
+    } else {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored) as Filters;
+          setFilters({ ...defaultFilters, ...parsed });
+        } catch {
+          setFilters(defaultFilters);
+        }
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // sync to URL and localStorage
+  useEffect(() => {
+    const params: Record<string, string> = {};
+    if (filters.meal.length) params.meal = filters.meal.join(',');
+    if (filters.diet.length) params.diet = filters.diet.join(',');
+    if (filters.allergy.length) params.allergy = filters.allergy.join(',');
+    if (filters.dish.length) params.dish = filters.dish.join(',');
+    if (filters.cuisine.length) params.cuisine = filters.cuisine.join(',');
+    if (filters.difficulty) params.difficulty = filters.difficulty;
+    if (filters.time) params.time = filters.time;
+    if (filters.feat.length) params.feat = filters.feat.join(',');
+    setSearchParams(params);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filters));
+  }, [filters, setSearchParams]);
+
+  const setFilter = (key: keyof Filters, value: string[] | string | null) => {
+    setFilters((prev) => ({ ...prev, [key]: value as any }));
+  };
+
+  const toggleFilter = (key: keyof Filters, option: string) => {
+    setFilters((prev) => {
+      const current = Array.isArray(prev[key]) ? (prev[key] as string[]) : [];
+      const next = current.includes(option)
+        ? current.filter((v) => v !== option)
+        : [...current, option];
+      return { ...prev, [key]: next as any };
+    });
+  };
+
+  const clearAll = () => setFilters(defaultFilters);
+
+  const isActive = useMemo(() => {
+    return (
+      filters.meal.length > 0 ||
+      filters.diet.length > 0 ||
+      filters.allergy.length > 0 ||
+      filters.dish.length > 0 ||
+      filters.cuisine.length > 0 ||
+      !!filters.difficulty ||
+      !!filters.time ||
+      filters.feat.length > 0
+    );
+  }, [filters]);
+
+  return { filters, setFilter, toggleFilter, clearAll, isActive };
+};
+
+export const applyFilters = (recipes: Recipe[], filters: Filters): Recipe[] => {
+  return recipes.filter((r) => {
+    if (filters.meal.length && !filters.meal.some((m) => (r.mealType || []).includes(m))) {
+      return false;
+    }
+    if (filters.diet.length && !filters.diet.some((m) => (r.diet || []).includes(m))) {
+      return false;
+    }
+    if (filters.allergy.length && !filters.allergy.some((m) => (r.allergies || []).includes(m))) {
+      return false;
+    }
+    if (filters.dish.length && !(filters.dish.includes(r.dishType || ''))) {
+      return false;
+    }
+    if (filters.cuisine.length && !(filters.cuisine.includes(r.cuisine || ''))) {
+      return false;
+    }
+    if (filters.difficulty && r.difficulty !== filters.difficulty) {
+      return false;
+    }
+    if (filters.time) {
+      const t = r.timeMinutes || 0;
+      switch (filters.time) {
+        case '15 minutes or less':
+          if (t > 15) return false;
+          break;
+        case '30 minutes or less':
+          if (t > 30) return false;
+          break;
+        case '45 minutes or less':
+          if (t > 45) return false;
+          break;
+        case '60 minutes or less':
+          if (t > 60) return false;
+          break;
+        case 'Over 60 minutes':
+          if (t <= 60) return false;
+          break;
+      }
+    }
+    if (filters.feat.length && !filters.feat.some((f) => (r.features || []).includes(f))) {
+      return false;
+    }
+    return true;
+  });
+};

--- a/src/pages/Browse.jsx
+++ b/src/pages/Browse.jsx
@@ -1,13 +1,12 @@
-import React, { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { supabase } from '../supabaseClient'
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { supabase } from '../supabaseClient';
+import FilterPanel from '../components/filters/FilterPanel';
+import { useRecipeFilters, applyFilters, Recipe } from '../hooks/useRecipeFilters';
 
-export default function Browse(){
-  const [recipes, setRecipes] = useState([])
-  const [q, setQ] = useState('')
-  const [diet, setDiet] = useState('')
-  const [meal, setMeal] = useState('')
-  const [maxTime, setMaxTime] = useState(180)
+export default function Browse() {
+  const [recipes, setRecipes] = useState<Recipe[]>([]);
+  const { filters, setFilter, clearAll, isActive } = useRecipeFilters();
 
   useEffect(() => {
     (async () => {
@@ -16,63 +15,67 @@ export default function Browse(){
         .select('*')
         .eq('status', 'approved')
         .order('created_at', { ascending: false })
-        .limit(200)
-      if (!error) setRecipes(data || [])
-    })()
-  }, [])
+        .limit(200);
+      if (!error) setRecipes((data as any) || []);
+    })();
+  }, []);
 
-  const filtered = recipes.filter(r => {
-    const hay = [r.title, r.description, r.ingredients, r.steps, (r.tags||[]).join(' ')].join(' ').toLowerCase()
-    const matchesQ = q ? hay.includes(q.toLowerCase()) : true
-    const matchesDiet = diet ? (r.diet||'').toLowerCase() === diet.toLowerCase() : true
-    const matchesMeal = meal ? (r.meal_type||'').toLowerCase() === meal.toLowerCase() : true
-    const matchesTime = typeof r.cook_time === 'number' ? r.cook_time <= maxTime : true
-    return matchesQ && matchesDiet && matchesMeal && matchesTime
-  })
+  const filtered = applyFilters(recipes, filters);
+  const featured = recipes.slice(0, 6);
+  const display = isActive ? filtered : featured;
 
   return (
-    <div className="grid gap-4">
-      <div className="rounded-2xl border border-neutral-200 bg-white p-4 grid gap-3 md:grid-cols-4">
-        <input value={q} onChange={e=>setQ(e.target.value)} placeholder="Search title, ingredients, tags…" className="rounded-xl border border-neutral-300 px-3 py-2 outline-none focus:ring-2 focus:ring-neutral-300 md:col-span-2" />
-        <select value={diet} onChange={e=>setDiet(e.target.value)} className="rounded-xl border border-neutral-300 px-3 py-2">
-          <option value="">Any diet</option>
-          <option>Vegetarian</option>
-          <option>Vegan</option>
-          <option>Pescatarian</option>
-          <option>Gluten-Free</option>
-          <option>Keto</option>
-          <option>None</option>
-        </select>
-        <select value={meal} onChange={e=>setMeal(e.target.value)} className="rounded-xl border border-neutral-300 px-3 py-2">
-          <option value="">Any meal</option>
-          <option>Breakfast</option>
-          <option>Lunch</option>
-          <option>Dinner</option>
-          <option>Snack</option>
-          <option>Dessert</option>
-        </select>
-        <div className="flex items-center gap-3 md:col-span-2">
-          <label className="text-sm text-neutral-600">Max time</label>
-          <input type="range" min={0} max={240} step={5} value={maxTime} onChange={e=>setMaxTime(Number(e.target.value))} className="w-full" />
-          <div className="text-sm w-16 text-right">{maxTime}m</div>
-        </div>
-      </div>
+    <div className="space-y-6">
+      <FilterPanel
+        filters={filters}
+        setFilter={setFilter}
+        clearAll={clearAll}
+        isActive={isActive}
+      />
+
+      <hr className="border-t border-neutral-200" />
+
+      {isActive ? (
+        <p className="text-sm text-neutral-600">{filtered.length} results</p>
+      ) : (
+        <h2 className="text-lg font-semibold">Featured Recipes</h2>
+      )}
 
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {filtered.map(r => (
-          <article key={r.id} className="rounded-2xl border border-neutral-200 bg-white p-4 hover:shadow-sm transition">
+        {display.map((r: any) => (
+          <article
+            key={r.id}
+            className="rounded-2xl border border-neutral-200 bg-white p-4 hover:shadow-sm transition"
+          >
             <div className="flex items-start justify-between gap-2">
               <h3 className="font-semibold leading-tight line-clamp-2">{r.title}</h3>
-              {typeof r.cook_time === 'number' && <span className="text-xs rounded-full px-2 py-0.5 border border-neutral-300">{r.cook_time}m</span>}
+              {typeof r.timeMinutes === 'number' || typeof r.cook_time === 'number' ? (
+                <span className="text-xs rounded-full px-2 py-0.5 border border-neutral-300">
+                  {r.timeMinutes ?? r.cook_time} min
+                </span>
+              ) : null}
             </div>
-            <p className="mt-1 text-sm text-neutral-600 line-clamp-2">{r.description}</p>
+            {'rating' in r && (
+              <div className="mt-1 text-sm text-yellow-500">
+                {('★'.repeat(Math.round(r.rating || 0)))}
+              </div>
+            )}
+            {r.description && (
+              <p className="mt-1 text-sm text-neutral-600 line-clamp-2">{r.description}</p>
+            )}
             <div className="mt-3 text-xs text-neutral-500">
-              <span>{r.meal_type || '—'}</span> • <span>{r.diet || '—'}</span>
+              <span>{r.meal_type || r.mealType?.join(', ') || '—'}</span> •{' '}
+              <span>{r.diet || (r.diet ? r.diet.join(', ') : '—')}</span>
             </div>
-            <Link to={`/recipe/${r.id}`} className="mt-3 inline-block text-sm underline underline-offset-2">View recipe</Link>
+            <Link
+              to={`/recipe/${r.id}`}
+              className="mt-3 inline-block text-sm underline underline-offset-2"
+            >
+              View recipe
+            </Link>
           </article>
         ))}
       </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add FilterChip, FilterGroup, and FilterPanel components with responsive chip UI and clear-all control
- implement useRecipeFilters hook with URL/localStorage persistence and applyFilters helper
- integrate filter panel and featured/results display into Browse page and add vitest test suite

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_689834d306208324aa5b83a4b8a0ae39