### PR TITLE
chore: remove placeholder logo from header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,10 +24,7 @@ export default function App(){
     <div className="min-h-screen bg-neutral-50 text-neutral-900">
       <header className="sticky top-0 z-10 bg-white/90 backdrop-blur border-b border-neutral-200">
         <div className="mx-auto max-w-6xl px-4 py-3 flex items-center gap-3">
-          <div className="flex items-center gap-2 font-semibold">
-            <div className="h-7 w-7 rounded-lg bg-neutral-900 text-white grid place-items-center">OY</div>
-            <span>OpenYum</span>
-          </div>
+          <div className="font-semibold">OpenYum</div>
           <nav className="ml-auto flex items-center gap-1">
             <NavItem to="/browse">Browse</NavItem>
             <NavItem to="/submit">Submit Recipe</NavItem>


### PR DESCRIPTION
## Summary
- replace placeholder `OY` logo with plain text title in header for a cleaner look

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68983503dac48324afee46113129909a